### PR TITLE
findAllStudentsのテストコードを作成

### DIFF
--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -60,8 +60,8 @@ class StudentServiceTest {
     }
 
     @Test
-    public void 接頭辞が溝である学生をクエリパラメータの検索を使用して取得すること() {
-        List<Student> getByStartWith = List.of(new Student(1, "溝口光一", "一年生", "大分県"));
+    public void 人名の頭文字が溝である学生をクエリパラメータの検索を使用して複数取得することを修正() {
+        List<Student> getByStartWith = studentMapper.findByName("溝");
         doReturn(getByStartWith).when(studentMapper).findByName("溝");
         List<Student> actualList = studentService.findAllStudents(null, "溝", null);
         assertThat(actualList).isEqualTo(getByStartWith);

--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -1,6 +1,7 @@
 package com.koichi.assignment8.service;
 
 import com.koichi.assignment8.entity.Student;
+import com.koichi.assignment8.excption.MultipleMethodsException;
 import com.koichi.assignment8.excption.StudentNotFoundException;
 import com.koichi.assignment8.mapper.StudentMapper;
 import org.junit.jupiter.api.Test;
@@ -72,5 +73,14 @@ class StudentServiceTest {
         doReturn(getByBirthPlace).when(studentMapper).findByBirthPlace("大分県");
         List<Student> actualList = studentService.findAllStudents(null, null, "大分県");
         assertThat(actualList).isEqualTo(getByBirthPlace);
+    }
+
+    @Test
+    public void クエリパラメータで複数のカラムを検索する時にカラムはgradestartsWithbirthPlaceの一つを選んでくださいというメッセージを返却すること() {
+        List<Student> findAllStudents = List.of(new Student(1, "溝口光一", "一年生", "大分県"));
+        doReturn(findAllStudents).when(studentMapper).findAllStudents();
+        assertThatThrownBy(() -> studentService.findAllStudents(null, "溝", "大分県"))
+                .isInstanceOf(MultipleMethodsException.class)
+                .hasMessage("カラムはgrade・startsWith・birthPlaceの一つを選んでください");
     }
 }

--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -49,4 +49,12 @@ class StudentServiceTest {
         List<Student> actualList = studentService.findAllStudents(null, null, null);
         assertThat(actualList).isEqualTo(findAllStudents);
     }
+
+    @Test
+    public void 一年生の学生をクエリパラメータの検索を使用して取得すること() {
+        List<Student> getByGrade = List.of(new Student(1, "溝口光一", "一年生", "大分県"));
+        doReturn(getByGrade).when(studentMapper).findByGrade("一年生");
+        List<Student> actualList = studentService.findAllStudents(1, null, null);
+        assertThat(actualList).isEqualTo(getByGrade);
+    }
 }

--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -57,12 +57,20 @@ class StudentServiceTest {
         List<Student> actualList = studentService.findAllStudents(1, null, null);
         assertThat(actualList).isEqualTo(getByGrade);
     }
-    
+
     @Test
     public void 接頭辞が溝である学生をクエリパラメータの検索を使用して取得すること() {
         List<Student> getByStartWith = List.of(new Student(1, "溝口光一", "一年生", "大分県"));
         doReturn(getByStartWith).when(studentMapper).findByName("溝");
         List<Student> actualList = studentService.findAllStudents(null, "溝", null);
         assertThat(actualList).isEqualTo(getByStartWith);
+    }
+
+    @Test
+    public void 大分県出身の学生をクエリパラメータの検索を使用して取得すること() {
+        List<Student> getByBirthPlace = List.of(new Student(1, "溝口光一", "一年生", "大分県"));
+        doReturn(getByBirthPlace).when(studentMapper).findByBirthPlace("大分県");
+        List<Student> actualList = studentService.findAllStudents(null, null, "大分県");
+        assertThat(actualList).isEqualTo(getByBirthPlace);
     }
 }

--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,5 +38,15 @@ class StudentServiceTest {
         assertThatThrownBy(() -> studentService.findStudent(1))
                 .isInstanceOf(StudentNotFoundException.class)
                 .hasMessage("student not found");
+    }
+
+    @Test
+    public void 全ての学生を取得すること() {
+        List<Student> findAllStudents = List.of(new Student(1, "溝口光一", "一年生", "大分県"),
+                new Student(2, "中野乃蒼", "二年生", "福岡県"),
+                new Student(3, "安藤健", "三年生", "熊本県"));
+        doReturn(findAllStudents).when(studentMapper).findAllStudents();
+        List<Student> actualList = studentService.findAllStudents(null, null, null);
+        assertThat(actualList).isEqualTo(findAllStudents);
     }
 }

--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -57,4 +57,12 @@ class StudentServiceTest {
         List<Student> actualList = studentService.findAllStudents(1, null, null);
         assertThat(actualList).isEqualTo(getByGrade);
     }
+    
+    @Test
+    public void 接頭辞が溝である学生をクエリパラメータの検索を使用して取得すること() {
+        List<Student> getByStartWith = List.of(new Student(1, "溝口光一", "一年生", "大分県"));
+        doReturn(getByStartWith).when(studentMapper).findByName("溝");
+        List<Student> actualList = studentService.findAllStudents(null, "溝", null);
+        assertThat(actualList).isEqualTo(getByStartWith);
+    }
 }


### PR DESCRIPTION
### ◎finAllStudentsのテストコードを作成しました。
 - ServiceにあるfindAllStudentsのメソッドに対してテストを行いました。
 - 今回は下記の５つについてテストを行いました。
    (1)全ての学生を取得すること
    (2)一年生の学生をクエリパラメータの検索を使用して取得すること
    (3)接頭辞が溝である学生をクエリパラメータの検索を使用して取得すること
    (4)大分県出身の学生をクエリパラメータの検索を使用して取得すること
    (5) クエリパラメータで複数のカラムを検索する時にカラムはgradestartsWithbirthPlaceの一つを選んでくださいという
         メッセージを返却すること

#### ◎動作確認
(1)全ての学生を取得すること
2355fb2d148a1ff9ea2833549eef8907b1969263
![スクリーンショット 2024-06-08 132306](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/20f9bd99-90f2-44c7-b41e-3cdc5f8c31bd)

(2)一年生の学生をクエリパラメータの検索を使用して取得すること
e81e547b0c88bfc3a7bbad87b6fb16d06d80470f
![スクリーンショット 2024-06-08 132332](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/be1b228d-7d9f-4bcc-a535-fa46536971a5)

(3)接頭辞が溝である学生をクエリパラメータの検索を使用して取得すること
041e5992a961aeb44cabc6116626c89eeb5fd19e
![スクリーンショット 2024-06-08 132347](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/cb52e1f8-4ad0-44a3-8552-9a6f040b29fc)

(4)大分県出身の学生をクエリパラメータの検索を使用して取得すること
566d05a1973c11cf9f9261d7d6a84aa19f29696d
![スクリーンショット 2024-06-08 132500](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/f62f56ee-2ecc-4f27-9b28-7779c5e4dc4f)

(5) クエリパラメータで複数のカラムを検索する時にカラムはgradestartsWithbirthPlaceの一つを選んでくださいという
     メッセージを返却すること
6fa527b38547365ea53618150e7e013e8bb3ccad
![スクリーンショット 2024-06-08 132533](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/c1267b2a-47b0-4726-b11e-57cbb052756a)
