### PR TITLE
IDの該当する学生のデータを更新すること

### DIFF
--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -16,6 +16,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class StudentServiceTest {
@@ -87,6 +89,19 @@ class StudentServiceTest {
     @Test
     public void IDに該当する学生のデータを更新出来ること() {
 
+        String name = "溝上航";
+        String grade = "一年生";
+        String birthPlace = "大分県";
 
+        Student expectedStudents = new Student(1, "内藤友美", "一年生", "福岡県");
+        doReturn(Optional.of(expectedStudents)).when(studentMapper).findById(1);
+        studentService.updateStudent(1, name, grade, birthPlace);
+
+        assertThat(expectedStudents.getName()).isEqualTo(name);
+        assertThat(expectedStudents.getGrade()).isEqualTo(grade);
+        assertThat(expectedStudents.getBirthPlace()).isEqualTo(birthPlace);
+        verify(studentMapper, times(1)).updateStudent(expectedStudents);
     }
+
+
 }

--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -109,7 +109,7 @@ class StudentServiceTest {
         String name = "溝上航";
         String grade = "一年生";
         String birthPlace = "大分県";
-        
+
         doReturn(Optional.empty()).when(studentMapper).findById(999);
         assertThatThrownBy(() -> studentService.updateStudent(999, "溝上航", "一年生", "福岡県"))
                 .isInstanceOf(StudentNotFoundException.class)

--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -83,4 +83,10 @@ class StudentServiceTest {
                 .isInstanceOf(MultipleMethodsException.class)
                 .hasMessage("カラムはgrade・startsWith・birthPlaceの一つを選んでください");
     }
+
+    @Test
+    public void IDに該当する学生のデータを更新出来ること() {
+
+
+    }
 }

--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -103,5 +103,16 @@ class StudentServiceTest {
         verify(studentMapper, times(1)).updateStudent(expectedStudents);
     }
 
+    @Test
+    public void 学生のデータを更新する際にIDに該当する学生がいない場合studentnotfoundというメッセージが返却されること() {
 
+        String name = "溝上航";
+        String grade = "一年生";
+        String birthPlace = "大分県";
+        
+        doReturn(Optional.empty()).when(studentMapper).findById(999);
+        assertThatThrownBy(() -> studentService.updateStudent(999, "溝上航", "一年生", "福岡県"))
+                .isInstanceOf(StudentNotFoundException.class)
+                .hasMessage("student not found");
+    }
 }


### PR DESCRIPTION
###  IDの該当する学生のデータを更新することのテストを作成
 - 今回は、以下の二つのテストを作成しました。
 -  ①IDの該当する学生のデータを更新することのテスト
 -  ②学生のデータを更新する際にIDに該当する学生がいない場合studentnotfoundというメッセージが返却されるテ 
        スト


####  ①IDの該当する学生のデータを更新することのテストを作成
d40200181bb28c17e1fe0ae6499bf12a9182b63c

![スクリーンショット 2024-06-20 101835](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/44367aba-b78d-4791-a3c4-75324945233e)

####  ②学生のデータを更新する際にIDに該当する学生がいない場合studentnotfoundというメッセージが返却されるテストを作成
7db9f9a94ddd13bc10f343938cd12359b0915ca3

![スクリーンショット 2024-06-20 101901](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/d826f98a-f1ce-4fa3-bb10-fafddb7d7fab)