### PR TITLE
findByIdのDBテストの作成

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     testImplementation("org.mockito:mockito-junit-jupiter:2.+")
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation("org.assertj:assertj-core:3.25.1")
+    implementation group: 'com.github.database-rider', name: 'rider-core', version: '1.42.0'
+    testImplementation group: 'com.github.database-rider', name: 'rider-junit5', version: '1.42.0'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
+++ b/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
@@ -32,4 +32,13 @@ class StudentMapperTest {
         );
     }
 
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    public void IDに該当する学生がいない場合空のOptionalを返すこと() {
+
+        Optional<Student> findById = studentMapper.findById(999);
+        assertThat(findById).isEmpty();
+    }
+
 }

--- a/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
+++ b/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
@@ -1,0 +1,35 @@
+package com.koichi.assignment8.mapper;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.junit5.api.DBRider;
+import com.koichi.assignment8.entity.Student;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DBRider
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class StudentMapperTest {
+
+    @Autowired
+    StudentMapper studentMapper;
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    public void IDに該当する学生が一件取得できること() {
+
+        Optional<Student> findById = studentMapper.findById(1);
+        assertThat(findById).contains(
+                new Student(1, "清⽔圭吾", "一年生", "大分県")
+        );
+    }
+
+}

--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -130,8 +130,9 @@ class StudentServiceTest {
         verify(studentMapper, times(1)).updateGrade("卒業生", "三年生");
         verify(studentMapper, times(1)).updateGrade("三年生", "二年生");
         verify(studentMapper, times(1)).updateGrade("二年生", "一年生");
-      
-    @Test  
+    }
+
+    @Test
     public void IDに該当する学生のデータを削除出来ること() {
 
         Student expectedStudents = new Student(1, "内藤友美", "一年生", "福岡県");

--- a/src/test/resources/datasets/students.yml
+++ b/src/test/resources/datasets/students.yml
@@ -1,0 +1,25 @@
+students:
+  - id: 1
+    name: "清⽔圭吾"
+    grade: "一年生"
+    birth_place: "大分県"
+  - id: 2
+    name: "田中圭"
+    grade: "一年生"
+    birth_place: "福岡県"
+  - id: 3
+    name: "岡崎徹"
+    grade: "二年生"
+    birth_place: "大分県"
+  - id: 4
+    name: "溝口光一"
+    grade: "二年生"
+    birth_place: "熊本県"
+  - id: 5
+    name: "溝谷望"
+    grade: "三年生"
+    birth_place: "熊本県"
+  - id: 6
+    name: "安藤孝弘"
+    grade: "三年生"
+    birth_place: "福岡県"

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,0 +1,9 @@
+cacheConnection: false
+cacheTableNames: false
+properties:
+  schema: students_database
+caseInsensitiveStrategy: LOWERCASE
+connectionConfig:
+  url: "jdbc:mysql://localhost:3307/students_database" # MySQLの場合
+  user: "user"
+  password: "password"


### PR DESCRIPTION
### ◎findByIdのDBテストの作成
今回は下記の二つについてDBテストを作成しました。
 - IDに該当する学生が一件取得できるDBテストの作成
 - IDに該当する学生がいない場合空のOptionalを返すDBテストの作成

ご確認よろしくお願いいたします。

#### ◎IDに該当する学生が一件取得できるDBテストの作成
b4db4ee452ccfd3dffc74b3c19a4fa2beaeddc26

![スクリーンショット 2024-06-24 155842](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/f2092bd0-684c-483c-ba26-e102bafdfd12)

#### ◎IDに該当する学生がいない場合空のOptionalを返すDBテストの作成
 
5ccb30e5429f194abe5d7b731bcfce1f5fe6c924

![スクリーンショット 2024-06-24 155926](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/51a10dfd-206e-49c0-a4b2-6285ef4d385d)

