### PR TITLE
findAllStudentsのDBテストを作成

### DIFF
--- a/src/main/java/com/koichi/assignment8/mapper/StudentMapper.java
+++ b/src/main/java/com/koichi/assignment8/mapper/StudentMapper.java
@@ -1,7 +1,12 @@
 package com.koichi.assignment8.mapper;
 
 import com.koichi.assignment8.entity.Student;
-import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,7 +40,7 @@ public interface StudentMapper {
      * 指定した接頭辞のstudentのデータを全て取得します。
      */
     @Select("SELECT * FROM students WHERE name LIKE CONCAT(#{startsWith}, '%') ")
-    List<Student> findByName(String startsWith);
+    List<Student> findByStartWith(String startsWith);
 
     /**
      * SELECT用のMapper

--- a/src/main/java/com/koichi/assignment8/service/StudentService.java
+++ b/src/main/java/com/koichi/assignment8/service/StudentService.java
@@ -50,7 +50,7 @@ public class StudentService {
 
         List<Student> getAllStudent = this.studentMapper.findAllStudents();
         List<Student> getByGrade = this.studentMapper.findByGrade(gradeConvertedToString.get(grade));
-        List<Student> getByStartWith = this.studentMapper.findByName(startsWith);
+        List<Student> getByStartWith = this.studentMapper.findByStartWith(startsWith);
         List<Student> getByBirthPlace = this.studentMapper.findByBirthPlace(birthPlace);
 
         int count = 0;

--- a/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
+++ b/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,6 +40,22 @@ class StudentMapperTest {
 
         Optional<Student> findById = studentMapper.findById(999);
         assertThat(findById).isEmpty();
+    }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    public void 全ての学生を取得すること() {
+
+        List<Student> findAllStudents = studentMapper.findAllStudents();
+        assertThat(findAllStudents).contains(
+                new Student(1, "清⽔圭吾", "一年生", "大分県"),
+                new Student(2, "田中圭", "一年生", "福岡県"),
+                new Student(3, "岡崎徹", "二年生", "大分県"),
+                new Student(4, "溝口光一", "二年生", "熊本県"),
+                new Student(5, "溝谷望", "三年生", "熊本県"),
+                new Student(6, "安藤孝弘", "三年生", "福岡県")
+        );
     }
 
 }

--- a/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
+++ b/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
@@ -58,4 +58,15 @@ class StudentMapperTest {
         );
     }
 
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    public void 一年生の学生をクエリパラメータの検索を使用して取得すること() {
+
+        List<Student> findByGrade = studentMapper.findByGrade("一年生");
+        assertThat(findByGrade).contains(
+                new Student(1, "清⽔圭吾", "一年生", "大分県"),
+                new Student(2, "田中圭", "一年生", "福岡県")
+        );
+    }
 }

--- a/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
+++ b/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
@@ -82,4 +82,16 @@ class StudentMapperTest {
         );
     }
 
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    public void 大分県出身の学生をクエリパラメータの検索を使用して取得すること() {
+
+        List<Student> findByBirthPlace = studentMapper.findByBirthPlace("大分県");
+        assertThat(findByBirthPlace).contains(
+                new Student(1, "清⽔圭吾", "一年生", "大分県"),
+                new Student(3, "岡崎徹", "二年生", "大分県")
+        );
+    }
 }

--- a/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
+++ b/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
@@ -70,5 +70,16 @@ class StudentMapperTest {
         );
     }
 
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    public void 人名の頭文字が溝である学生をクエリパラメータの検索を使用して複数取得すること() {
+
+        List<Student> getByStartWith = studentMapper.findByStartWith("溝");
+        assertThat(getByStartWith).contains(
+                new Student(4, "溝口光一", "二年生", "熊本県"),
+                new Student(5, "溝谷望", "三年生", "熊本県")
+        );
+    }
 
 }

--- a/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
+++ b/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
@@ -69,4 +69,6 @@ class StudentMapperTest {
                 new Student(2, "田中圭", "一年生", "福岡県")
         );
     }
+
+
 }

--- a/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
+++ b/src/test/java/com/koichi/assignment8/service/StudentServiceTest.java
@@ -62,9 +62,9 @@ class StudentServiceTest {
     }
 
     @Test
-    public void 人名の頭文字が溝である学生をクエリパラメータの検索を使用して複数取得することを修正() {
-        List<Student> getByStartWith = studentMapper.findByName("溝");
-        doReturn(getByStartWith).when(studentMapper).findByName("溝");
+    public void 人名の頭文字が溝である学生をクエリパラメータの検索を使用して複数取得すること() {
+        List<Student> getByStartWith = studentMapper.findByStartWith("溝");
+        doReturn(getByStartWith).when(studentMapper).findByStartWith("溝");
         List<Student> actualList = studentService.findAllStudents(null, "溝", null);
         assertThat(actualList).isEqualTo(getByStartWith);
     }


### PR DESCRIPTION
### ◎findAllStudentsのDBテストを作成
今回は以下の4つについてDBテストの作成をしました。
 - 全ての学生を取得すること
 - 一年生の学生をクエリパラメータの検索を使用して取得すること
 - 人名の頭文字が溝である学生をクエリパラメータの検索を使用して複数取得すること
 - 大分県出身の学生をクエリパラメータの検索を使用して取得すること

ご確認よろしくお願いいたします。

#### ◎全ての学生を取得すること
92accadde164645553926b95d604866f027c0ed3

![スクリーンショット 2024-06-25 135051](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/061da952-eb6a-4528-b92a-1d0225ec8525)

#### ◎一年生の学生をクエリパラメータの検索を使用して取得すること
18b05a54ac91efaf7ff2e19065e1d5e603a5fd57

![スクリーンショット 2024-06-25 135126](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/6fd7edf8-8f65-4c3f-b3da-06b8331ab65a)

#### ◎人名の頭文字が溝である学生をクエリパラメータの検索を使用して複数取得すること

ここのDBテストの作成の前に、メソッド名が統一されていなかったので、下記のコミットにて
findByStartWithに統一しました。
120a7907ebc7b5f3bf7514ef74accba7b94e294b

次に、下記のコミットにてDBテストの作成しました。
5fe3515053b1046a408534aa5ecde15e881329fc

![スクリーンショット 2024-06-25 135142](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/025e5560-39c4-4751-96a1-09e6470b071f)

#### ◎大分県出身の学生をクエリパラメータの検索を使用して取得するDBテストの作成
c7a4c3a894e1c1beac64aa11e5fe3a6accc2934f

![スクリーンショット 2024-06-25 135222](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/5913a36a-584e-4e3e-b4fc-0d8535d0f3a5)
