### PR TITLE
学生の学年の進級されるDBテストの作成

### DIFF
--- a/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
+++ b/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
@@ -113,4 +113,15 @@ class StudentMapperTest {
         Student renewingStudent = new Student(1, "城野健一", "二年生", "福岡県");
         studentMapper.updateStudent(renewingStudent);
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/gradeAdvancement.yml")
+    @Transactional
+    public void 学生の学年を進級させること() {
+
+        studentMapper.updateGrade("卒業生", "三年生");
+        studentMapper.updateGrade("三年生", "二年生");
+        studentMapper.updateGrade("二年生", "一年生");
+    }
 }

--- a/src/test/resources/datasets/gradeAdvancement.yml
+++ b/src/test/resources/datasets/gradeAdvancement.yml
@@ -1,0 +1,25 @@
+students:
+  - id: 1
+    name: "清⽔圭吾"
+    grade: "二年生"
+    birth_place: "大分県"
+  - id: 2
+    name: "田中圭"
+    grade: "二年生"
+    birth_place: "福岡県"
+  - id: 3
+    name: "岡崎徹"
+    grade: "三年生"
+    birth_place: "大分県"
+  - id: 4
+    name: "溝口光一"
+    grade: "三年生"
+    birth_place: "熊本県"
+  - id: 5
+    name: "溝谷望"
+    grade: "卒業生"
+    birth_place: "熊本県"
+  - id: 6
+    name: "安藤孝弘"
+    grade: "卒業生"
+    birth_place: "福岡県"


### PR DESCRIPTION
### ◎学生の学年を進級されるDBテストの作成
今回は、学生の学年を進級されるDBテストの作成しました。
ご確認よろしくお願いいたします。

#### ○gradeAdvancement.ymlの作成
 - 学年の進級後のDBテストを作成しました。
d62ac79687701ad08eeb31f418e2dfa53af390f3

#### ○学年を進級させるDBテストの作成
49d59f5cd085738aa4e4f09e841306c0f036aff1

### ◎動作確認
![スクリーンショット 2024-07-01 120214](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/93ea8ce5-c8ac-40fe-b574-883d7ce9f7c8)
