### PR TITLE
IDに該当する学生のデータを削除出来るDBテストの作成

### DIFF
--- a/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
+++ b/src/test/java/com/koichi/assignment8/mapper/StudentMapperTest.java
@@ -124,4 +124,13 @@ class StudentMapperTest {
         studentMapper.updateGrade("三年生", "二年生");
         studentMapper.updateGrade("二年生", "一年生");
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/studentsToRemoved.yml")
+    @Transactional
+    public void IDに該当する学生のデータを削除出来ること() {
+
+        studentMapper.deleteStudent(1);
+    }
 }

--- a/src/test/resources/datasets/studentsToRemoved.yml
+++ b/src/test/resources/datasets/studentsToRemoved.yml
@@ -1,0 +1,21 @@
+students:
+  - id: 2
+    name: "田中圭"
+    grade: "一年生"
+    birth_place: "福岡県"
+  - id: 3
+    name: "岡崎徹"
+    grade: "二年生"
+    birth_place: "大分県"
+  - id: 4
+    name: "溝口光一"
+    grade: "二年生"
+    birth_place: "熊本県"
+  - id: 5
+    name: "溝谷望"
+    grade: "三年生"
+    birth_place: "熊本県"
+  - id: 6
+    name: "安藤孝弘"
+    grade: "三年生"
+    birth_place: "福岡県"


### PR DESCRIPTION
### ◎IDに該当する学生のデータを削除出来るDBテストの作成
今回、IDに該当する学生のデータを削除出来るDBテストの作成しました。
ご確認ください。

#### ○studentsToRemoved.ymlの作成
 - IDが１の方のデータを削除しているDBを作成しました。
e8bdd45a12e04c7e34430f6389ae2e0bb096e6c8

#### ○IDに該当する学生のデータ削除するDBテストの作成

925c33942df4e4559d7c3f9b84b6f08eee2818d5

### 動作確認
![スクリーンショット 2024-07-02 092324](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/023226ee-75d8-49f5-8e30-fc79ae1dbd07)
