### PR TITLE
findByIdの結合テストの作成

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation("org.assertj:assertj-core:3.25.1")
     implementation group: 'com.github.database-rider', name: 'rider-spring', version: '1.42.0'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '5.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
+++ b/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -16,11 +17,13 @@ import java.util.Map;
 @ControllerAdvice
 public class StudentControllerAdvice {
 
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd 'T'HH:mm:ssZ'［'VV'］'");
+
     @ExceptionHandler(value = StudentNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleUserNotFoundException(
             StudentNotFoundException e, HttpServletRequest request) {
         Map<String, String> body = Map.of(
-                "timestamp", ZonedDateTime.now().toString(),
+                "timestamp", ZonedDateTime.now().format(formatter),
                 "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
                 "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
                 "message", e.getMessage(),

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -36,4 +36,21 @@ public class studentApiIntegrationTest {
                         }                                                          
                         """));
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    void IDに該当する学生がいない時にStudentNotFoundExceptionのレスポンスボティが返却されること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/students/999"))
+                .andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                          "error": "Not Found",
+                          "path": "/students/999",
+                          "status": "404",
+                          "message": "student not found"
+                        }                                                      
+                        """));
+    }
+
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -52,5 +52,5 @@ public class studentApiIntegrationTest {
                         }                                                      
                         """));
     }
-
 }
+

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -1,11 +1,39 @@
 package com.koichi.assignment8.itegrationtest;
 
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public class studentApiIntegrationTest {
 
+    @Autowired
+    MockMvc mockMvc;
 
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    void IDに該当する学生が一件取得できること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/students/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                          "id": 1,
+                          "name": "清⽔圭吾",
+                          "grade": "一年生",
+                          "birthPlace": "大分県"
+                        }                                                          
+                        """));
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -1,0 +1,11 @@
+package com.koichi.assignment8.itegrationtest;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class studentApiIntegrationTest {
+
+
+}


### PR DESCRIPTION
### ◎findByIdの結合テストの作成
今回は以下の二つについて結合テストを行いました。
 - IDに該当する学生が一件取得できる結合テスト
 - IDに該当する学生がいない時にStudentNotFoundExceptionのレスポンスボティが返却される結合テスト
ご確認よろしくお願いいたします。

#### ○IDに該当する学生が一件取得できる結合テスト
67d7fa709744bd03d593a0219f117fa57b4a2ec2

![スクリーンショット 2024-07-03 120244](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/977cfb2b-543f-4fe9-b58e-fde4f9cfe2ce)


#### ○IDに該当する学生がいない時にStudentNotFoundExceptionのレスポンスボティが返却される結合テスト
667f75dd5f4c64e8451ca396b61739407055b613
 - 実際のレスポンスボティには、timestampがありますが、テストのやり方が分からなかったので、
   timestampを消してテストしております。


![スクリーンショット 2024-07-03 120600](https://github.com/mizoguchi-kouichi/assignment8/assets/156568693/a0ed5710-accc-4933-9da0-f3d73960bc53)