### PR TITLE
ControllerのgetStudentsメソッドについて結合テストの作成

### DIFF
--- a/src/main/java/com/koichi/assignment8/controller/StudentController.java
+++ b/src/main/java/com/koichi/assignment8/controller/StudentController.java
@@ -8,7 +8,14 @@ import com.koichi.assignment8.service.StudentService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;

--- a/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
+++ b/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
@@ -32,7 +32,7 @@ public class StudentControllerAdvice {
     }
 
     @ExceptionHandler(value = MultipleMethodsException.class)
-    public ResponseEntity<Map<String, String>> handleUserNotFoundException(
+    public ResponseEntity<Map<String, String>> handleMultipleMethodsException(
             MultipleMethodsException e, HttpServletRequest request) {
         Map<String, String> body = Map.of(
                 "timestamp", ZonedDateTime.now().format(formatter),

--- a/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
+++ b/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -39,6 +40,18 @@ public class StudentControllerAdvice {
                 "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
                 "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
                 "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<Map<String, String>> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().format(formatter),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", "gradeは、1~4のどれかを入力してください",
                 "path", request.getRequestURI());
         return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
+++ b/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
@@ -35,7 +35,7 @@ public class StudentControllerAdvice {
     public ResponseEntity<Map<String, String>> handleUserNotFoundException(
             MultipleMethodsException e, HttpServletRequest request) {
         Map<String, String> body = Map.of(
-                "timestamp", ZonedDateTime.now().toString(),
+                "timestamp", ZonedDateTime.now().format(formatter),
                 "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
                 "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
                 "message", e.getMessage(),
@@ -55,7 +55,7 @@ public class StudentControllerAdvice {
         });
 
         ErrorResponse errorResponse =
-                new ErrorResponse(String.valueOf(HttpStatus.BAD_REQUEST.value()), "validation error", ZonedDateTime.now().toString(), errors);
+                new ErrorResponse(String.valueOf(HttpStatus.BAD_REQUEST.value()), "validation error", ZonedDateTime.now().format(formatter), errors);
         return ResponseEntity.badRequest().body(errorResponse);
     }
 

--- a/src/main/java/com/koichi/assignment8/mapper/StudentMapper.java
+++ b/src/main/java/com/koichi/assignment8/mapper/StudentMapper.java
@@ -46,7 +46,7 @@ public interface StudentMapper {
      * SELECT用のMapper
      * 指定した出身地のstudentのデータを全て取得します。
      */
-    @Select("SELECT * FROM students WHERE birth_place = #{birthplace}")
+    @Select("SELECT * FROM students WHERE birth_place = #{birthPlace}")
     List<Student> findByBirthPlace(String birthPlace);
 
     /**

--- a/src/main/java/com/koichi/assignment8/service/StudentService.java
+++ b/src/main/java/com/koichi/assignment8/service/StudentService.java
@@ -58,14 +58,15 @@ public class StudentService {
         if (grade != null) {
             count++;
         }
+
         if (startsWith != null) {
             count++;
         }
 
-
         if (birthPlace != null) {
             count++;
         }
+
 
         if (count >= 2) {
             throw new MultipleMethodsException("カラムはgrade・startsWith・birthPlaceの一つを選んでください");

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -278,5 +278,16 @@ public class studentApiIntegrationTest {
                              """));
         }
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    void 実際にいない人名の頭文字でクエリパラメータの検索を使用したらEmptyを返すこと() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/students?startsWith=阿"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        []
+                         """));
+    }
 }
 

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -184,7 +184,7 @@ public class studentApiIntegrationTest {
                         ]
                          """));
     }
-    
+
     @Test
     @DataSet(value = "datasets/students.yml")
     @Transactional
@@ -252,6 +252,29 @@ public class studentApiIntegrationTest {
                                "error": "Bad Request",
                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］"
                             }
+                             """));
+        }
+    }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    void 学年でクエリパラメータの検索を使用する際に文字列を入力した時にMethodArgumentTypeMismatchExceptionのレスポンスボティが返却されること() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+            mockMvc.perform(MockMvcRequestBuilders.get("/students?grade=一年生"))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                               "path": "/students",
+                               "status": "400",
+                               "message": "gradeは、1~4のどれかを入力してください",
+                               "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                               "error": "Bad Request"
+                             }
                              """));
         }
     }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -113,5 +113,29 @@ public class studentApiIntegrationTest {
                          """));
     }
 
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    void 一年生の学生をクエリパラメータの検索を使用して取得すること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/students?grade=1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                           {
+                             "id": 1,
+                             "name": "清⽔圭吾",
+                             "grade": "一年生",
+                             "birthPlace": "大分県"
+                           },
+                           {
+                             "id": 2,
+                             "name": "田中圭",
+                             "grade": "一年生",
+                             "birthPlace": "福岡県"
+                           }
+                        ]
+                         """));
+    }
+
 }
 

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -64,5 +64,54 @@ public class studentApiIntegrationTest {
                             """));
         }
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    void 全ての学生を取得すること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/students"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                           {
+                             "id": 1,
+                             "name": "清⽔圭吾",
+                             "grade": "一年生",
+                             "birthPlace": "大分県"
+                           },
+                           {
+                             "id": 2,
+                             "name": "田中圭",
+                             "grade": "一年生",
+                             "birthPlace": "福岡県"
+                           },
+                           {
+                             "id": 3,
+                             "name": "岡崎徹",
+                             "grade": "二年生",
+                             "birthPlace": "大分県"
+                           },
+                           {
+                             "id": 4,
+                             "name": "溝口光一",
+                             "grade": "二年生",
+                             "birthPlace": "熊本県"
+                           },
+                           {
+                             "id": 5,
+                             "name": "溝谷望",
+                             "grade": "三年生",
+                             "birthPlace": "熊本県"
+                           },
+                           {
+                             "id": 6,
+                             "name": "安藤孝弘",
+                             "grade": "三年生",
+                             "birthPlace": "福岡県"
+                           }
+                        ]
+                         """));
+    }
+
 }
 

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -289,5 +289,16 @@ public class studentApiIntegrationTest {
                         []
                          """));
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    void 実際にいない出身地でクエリパラメータの検索を使用したらEmptyを返すこと() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/students?birthPlace=大阪府"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        []
+                         """));
+    }
 }
 

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -184,5 +184,28 @@ public class studentApiIntegrationTest {
                         ]
                          """));
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    void クエリパラメータの検索を使用してカラムを2つ以上を選んだ時にMultipleMethodsExceptionのレスポンスボティが返却されること() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+            mockMvc.perform(MockMvcRequestBuilders.get("/students?grade=1&birthPlace=大分県"))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                               "message": "カラムはgrade・startsWith・birthPlaceの一つを選んでください",
+                               "status": "400",
+                               "path": "/students",
+                               "error": "Bad Request",
+                               "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］"
+                            }
+                             """));
+        }
+    }
 }
 

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -184,6 +184,54 @@ public class studentApiIntegrationTest {
                         ]
                          """));
     }
+    
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    void 実際にないカラムでクエリパラメータの検索を使用して取得する際に全ての学生を取得すること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/students?gender=男性"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                           {
+                             "id": 1,
+                             "name": "清⽔圭吾",
+                             "grade": "一年生",
+                             "birthPlace": "大分県"
+                           },
+                           {
+                             "id": 2,
+                             "name": "田中圭",
+                             "grade": "一年生",
+                             "birthPlace": "福岡県"
+                           },
+                           {
+                             "id": 3,
+                             "name": "岡崎徹",
+                             "grade": "二年生",
+                             "birthPlace": "大分県"
+                           },
+                           {
+                             "id": 4,
+                             "name": "溝口光一",
+                             "grade": "二年生",
+                             "birthPlace": "熊本県"
+                           },
+                           {
+                             "id": 5,
+                             "name": "溝谷望",
+                             "grade": "三年生",
+                             "birthPlace": "熊本県"
+                           },
+                           {
+                             "id": 6,
+                             "name": "安藤孝弘",
+                             "grade": "三年生",
+                             "birthPlace": "福岡県"
+                           }
+                        ]
+                         """));
+    }
 
     @Test
     @DataSet(value = "datasets/students.yml")

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -137,5 +137,28 @@ public class studentApiIntegrationTest {
                          """));
     }
 
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    void 人名の頭文字が溝である学生をクエリパラメータの検索を使用して複数取得すること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/students?startsWith=溝"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                           {
+                             "id": 4,
+                             "name": "溝口光一",
+                             "grade": "二年生",
+                             "birthPlace": "熊本県"
+                           },
+                           {
+                             "id": 5,
+                             "name": "溝谷望",
+                             "grade": "三年生",
+                             "birthPlace": "熊本県"
+                           }
+                        ]
+                         """));
+    }
 }
 

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -160,5 +160,29 @@ public class studentApiIntegrationTest {
                         ]
                          """));
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
+    void 大分県出身の学生をクエリパラメータの検索を使用して取得すること() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/students?birthPlace=大分県"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        [
+                           {
+                             "id": 1,
+                             "name": "清⽔圭吾",
+                             "grade": "一年生",
+                             "birthPlace": "大分県"
+                           },
+                           {
+                             "id": 3,
+                             "name": "岡崎徹",
+                             "grade": "二年生",
+                             "birthPlace": "大分県"
+                           }
+                        ]
+                         """));
+    }
 }
 


### PR DESCRIPTION
### ◎ControllerのgetStudentsメソッドについて結合テストの作成

今回は、以下の4つのついて結合テストの作成を作成しました。
 - 全ての学生を取得すること
 - 一年生の学生をクエリパラメータの検索を使用して取得すること
 - 人名の頭文字が溝である学生をクエリパラメータの検索を使用して複数取得すること
 - 大分県出身の学生をクエリパラメータの検索を使用して取得すること
 
ご確認よろしくお願いいたします。

#### ○全て学生を取得する結合テストの作成
aec88cbfd40487a30188281ad4bb7f4433bb1e72

![スクリーンショット 2024-07-12 133418](https://github.com/user-attachments/assets/303c3628-22d8-4647-88a9-d3c85b969edf)

#### ○一年生の学生をクエリパラメータの検索を使用して取得する結合テストの作成

99912c13db950fe452d038e3f6ec260b7fe30b1b

![スクリーンショット 2024-07-12 133448](https://github.com/user-attachments/assets/1ddcf324-4737-4001-beb8-63fd25ff09fd)


#### ○人名の頭文字が溝である学生をクエリパラメータの検索を使用して複数取得する結合テストの作成

bdfc04c4f5c275fc19c646b282d82fb56bb0b22c

![スクリーンショット 2024-07-12 133508](https://github.com/user-attachments/assets/2cd49c93-f6f0-40b1-98c7-f627510d2665)

#### ○大分県出身の学生をクエリパラメータの検索を使用して取得する結合テストの作成

ce49724d90572ea885c05e79814096efcb6c75c5

![スクリーンショット 2024-07-12 133524](https://github.com/user-attachments/assets/cec4fc08-16bc-449d-929e-50ab10a5f333)
