### PR TITLE
insertStudentの結合テストの作成

### DIFF
--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -36,10 +36,10 @@ public class studentApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""
                         {
-                          "id": 1,
-                          "name": "清⽔圭吾",
-                          "grade": "一年生",
-                          "birthPlace": "大分県"
+                            "id": 1,
+                            "name": "清⽔圭吾",
+                            "grade": "一年生",
+                            "birthPlace": "大分県"
                         }                                                          
                         """));
     }
@@ -57,11 +57,11 @@ public class studentApiIntegrationTest {
                     .andExpect(MockMvcResultMatchers.status().isNotFound())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                              "error": "Not Found",
-                              "path": "/students/999",
-                              "status": "404",
-                              "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                              "message": "student not found"
+                                "error": "Not Found",
+                                "path": "/students/999",
+                                "status": "404",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "message": "student not found"
                             }                                                      
                             """));
         }
@@ -75,42 +75,42 @@ public class studentApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""
                         [
-                           {
-                             "id": 1,
-                             "name": "清⽔圭吾",
-                             "grade": "一年生",
-                             "birthPlace": "大分県"
-                           },
-                           {
-                             "id": 2,
-                             "name": "田中圭",
-                             "grade": "一年生",
-                             "birthPlace": "福岡県"
-                           },
-                           {
-                             "id": 3,
-                             "name": "岡崎徹",
-                             "grade": "二年生",
-                             "birthPlace": "大分県"
-                           },
-                           {
-                             "id": 4,
-                             "name": "溝口光一",
-                             "grade": "二年生",
-                             "birthPlace": "熊本県"
-                           },
-                           {
-                             "id": 5,
-                             "name": "溝谷望",
-                             "grade": "三年生",
-                             "birthPlace": "熊本県"
-                           },
-                           {
-                             "id": 6,
-                             "name": "安藤孝弘",
-                             "grade": "三年生",
-                             "birthPlace": "福岡県"
-                           }
+                            {
+                                "id": 1,
+                                "name": "清⽔圭吾",
+                                "grade": "一年生",
+                                "birthPlace": "大分県"
+                            },
+                            {
+                                "id": 2,
+                                "name": "田中圭",
+                                "grade": "一年生",
+                                "birthPlace": "福岡県"
+                            },
+                            {
+                                "id": 3,
+                                "name": "岡崎徹",
+                                "grade": "二年生",
+                                "birthPlace": "大分県"
+                            },
+                            {
+                                "id": 4,
+                                "name": "溝口光一",
+                                "grade": "二年生",
+                                "birthPlace": "熊本県"
+                            },
+                            {
+                                "id": 5,
+                                "name": "溝谷望",
+                                "grade": "三年生",
+                                "birthPlace": "熊本県"
+                            },
+                            {
+                                "id": 6,
+                                "name": "安藤孝弘",
+                                "grade": "三年生",
+                                "birthPlace": "福岡県"
+                            }
                         ]
                          """));
     }
@@ -123,18 +123,18 @@ public class studentApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""
                         [
-                           {
-                             "id": 1,
-                             "name": "清⽔圭吾",
-                             "grade": "一年生",
-                             "birthPlace": "大分県"
-                           },
-                           {
-                             "id": 2,
-                             "name": "田中圭",
-                             "grade": "一年生",
-                             "birthPlace": "福岡県"
-                           }
+                            {
+                                "id": 1,
+                                "name": "清⽔圭吾",
+                                "grade": "一年生",
+                                "birthPlace": "大分県"
+                            },
+                            {
+                                "id": 2,
+                                "name": "田中圭",
+                                "grade": "一年生",
+                                "birthPlace": "福岡県"
+                            }
                         ]
                          """));
     }
@@ -147,18 +147,18 @@ public class studentApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""
                         [
-                           {
-                             "id": 4,
-                             "name": "溝口光一",
-                             "grade": "二年生",
-                             "birthPlace": "熊本県"
-                           },
-                           {
-                             "id": 5,
-                             "name": "溝谷望",
-                             "grade": "三年生",
-                             "birthPlace": "熊本県"
-                           }
+                            {
+                                "id": 4,
+                                "name": "溝口光一",
+                                "grade": "二年生",
+                                "birthPlace": "熊本県"
+                            },
+                            {
+                                "id": 5,
+                                "name": "溝谷望",
+                                "grade": "三年生",
+                                "birthPlace": "熊本県"
+                            }
                         ]
                          """));
     }
@@ -171,18 +171,18 @@ public class studentApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""
                         [
-                           {
-                             "id": 1,
-                             "name": "清⽔圭吾",
-                             "grade": "一年生",
-                             "birthPlace": "大分県"
-                           },
-                           {
-                             "id": 3,
-                             "name": "岡崎徹",
-                             "grade": "二年生",
-                             "birthPlace": "大分県"
-                           }
+                            {
+                                "id": 1,
+                                "name": "清⽔圭吾",
+                                "grade": "一年生",
+                                "birthPlace": "大分県"
+                            },
+                            {
+                                "id": 3,
+                                "name": "岡崎徹",
+                                "grade": "二年生",
+                                "birthPlace": "大分県"
+                            }
                         ]
                          """));
     }
@@ -195,42 +195,42 @@ public class studentApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""
                         [
-                           {
-                             "id": 1,
-                             "name": "清⽔圭吾",
-                             "grade": "一年生",
-                             "birthPlace": "大分県"
-                           },
-                           {
-                             "id": 2,
-                             "name": "田中圭",
-                             "grade": "一年生",
-                             "birthPlace": "福岡県"
-                           },
-                           {
-                             "id": 3,
-                             "name": "岡崎徹",
-                             "grade": "二年生",
-                             "birthPlace": "大分県"
-                           },
-                           {
-                             "id": 4,
-                             "name": "溝口光一",
-                             "grade": "二年生",
-                             "birthPlace": "熊本県"
-                           },
-                           {
-                             "id": 5,
-                             "name": "溝谷望",
-                             "grade": "三年生",
-                             "birthPlace": "熊本県"
-                           },
-                           {
-                             "id": 6,
-                             "name": "安藤孝弘",
-                             "grade": "三年生",
-                             "birthPlace": "福岡県"
-                           }
+                            {
+                                "id": 1,
+                                "name": "清⽔圭吾",
+                                "grade": "一年生",
+                                "birthPlace": "大分県"
+                            },
+                            {
+                                "id": 2,
+                                "name": "田中圭",
+                                "grade": "一年生",
+                                "birthPlace": "福岡県"
+                            },
+                            {
+                                "id": 3,
+                                "name": "岡崎徹",
+                                "grade": "二年生",
+                                "birthPlace": "大分県"
+                            },
+                            {
+                                "id": 4,
+                                "name": "溝口光一",
+                                "grade": "二年生",
+                                "birthPlace": "熊本県"
+                            },
+                            {
+                                "id": 5,
+                                "name": "溝谷望",
+                                "grade": "三年生",
+                                "birthPlace": "熊本県"
+                            },
+                            {
+                                "id": 6,
+                                "name": "安藤孝弘",
+                                "grade": "三年生",
+                                "birthPlace": "福岡県"
+                            }
                         ]
                          """));
     }
@@ -248,11 +248,11 @@ public class studentApiIntegrationTest {
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                               "message": "カラムはgrade・startsWith・birthPlaceの一つを選んでください",
-                               "status": "400",
-                               "path": "/students",
-                               "error": "Bad Request",
-                               "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］"
+                                "message": "カラムはgrade・startsWith・birthPlaceの一つを選んでください",
+                                "status": "400",
+                                "path": "/students",
+                                "error": "Bad Request",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］"
                             }
                              """));
         }
@@ -271,12 +271,12 @@ public class studentApiIntegrationTest {
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                               "path": "/students",
-                               "status": "400",
-                               "message": "gradeは、1~4のどれかを入力してください",
-                               "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                               "error": "Bad Request"
-                             }
+                                "path": "/students",
+                                "status": "400",
+                                "message": "gradeは、1~4のどれかを入力してください",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "error": "Bad Request"
+                            }
                              """));
         }
     }
@@ -313,17 +313,17 @@ public class studentApiIntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/students")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
-                                 {
-                                   "name":"中田健太",
-                                   "grade":"一年生",
-                                   "birthPlace":"福岡県"
-                                 }
+                                {
+                                    "name":"中田健太",
+                                    "grade":"一年生",
+                                    "birthPlace":"福岡県"
+                                }
                                 """))
                 .andExpect(MockMvcResultMatchers.status().isCreated())
                 .andExpect(MockMvcResultMatchers.content().json("""
                         {
-                            "message": "student created"
-                        }
+                             "message": "student created"
+                         }
                         """));
 
     }
@@ -342,25 +342,25 @@ public class studentApiIntegrationTest {
             mockMvc.perform(MockMvcRequestBuilders.post("/students")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                                     {
-                                       "name":"",
-                                       "grade":"一年生",
-                                       "birthPlace":"福岡県"
-                                     }
+                                    {
+                                        "name":"",
+                                        "grade":"一年生",
+                                        "birthPlace":"福岡県"
+                                    } 
                                     """))
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                                 "status": "400",
-                                 "message": "validation error",
-                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                                 "errors": [
+                                "status": "400",
+                                "message": "validation error",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "errors": [
                                      {
                                          "field": "name",
                                          "message": "nameを入力してください"
                                      }
-                                 ]
-                             }
+                                ]
+                            }
                             """));
         }
     }
@@ -379,25 +379,25 @@ public class studentApiIntegrationTest {
             mockMvc.perform(MockMvcRequestBuilders.post("/students")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                                     {
-                                       "name":"中田健太",
-                                       "grade":"",
-                                       "birthPlace":"福岡県"
-                                     }
+                                    {
+                                        "name":"中田健太",
+                                        "grade":"",
+                                        "birthPlace":"福岡県"
+                                    }
                                     """))
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                                  "status": "400",
-                                  "message": "validation error",
-                                  "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                                  "errors": [
-                                      {
-                                          "field": "grade",
-                                          "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
-                                      }
-                                  ]
-                              }
+                                 "status": "400",
+                                 "message": "validation error",
+                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                 "errors": [
+                                     {
+                                         "field": "grade",
+                                         "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
+                                     }
+                                 ]
+                            }
                             """));
         }
     }
@@ -416,25 +416,25 @@ public class studentApiIntegrationTest {
             mockMvc.perform(MockMvcRequestBuilders.post("/students")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                                     {
-                                       "name":"中田健太",
-                                       "grade":"1",
-                                       "birthPlace":"福岡県"
+                                    {
+                                         "name":"中田健太",
+                                         "grade":"1",
+                                         "birthPlace":"福岡県"
                                      }
                                     """))
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                                  "status": "400",
-                                  "message": "validation error",
-                                  "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                                  "errors": [
-                                      {
-                                          "field": "grade",
-                                          "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
-                                      }
-                                  ]
-                              }
+                                 "status": "400",
+                                 "message": "validation error",
+                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                 "errors": [
+                                     {
+                                         "field": "grade",
+                                         "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
+                                     }
+                                 ]
+                            }
                             """));
         }
     }
@@ -453,28 +453,26 @@ public class studentApiIntegrationTest {
             mockMvc.perform(MockMvcRequestBuilders.post("/students")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content("""
-                                     {
-                                       "name":"中田健太",
-                                       "grade":"一年生",
-                                       "birthPlace":""
-                                     }
+                                    {
+                                        "name":"中田健太",
+                                        "grade":"一年生",
+                                        "birthPlace":""
+                                    }                                    
                                     """))
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                                   "status": "400",
-                                   "message": "validation error",
-                                   "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                                   "errors": [
-                                       {
-                                           "field": "birthPlace",
-                                           "message": "birthPlaceを入力してください"
-                                       }
-                                   ]
-                               }
+                                 "status": "400",
+                                 "message": "validation error",
+                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                 "errors": [
+                                     {
+                                         "field": "birthPlace",
+                                         "message": "birthPlaceを入力してください"
+                                     }
+                                 ]
+                            }
                             """));
         }
     }
-
-
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -438,4 +438,41 @@ public class studentApiIntegrationTest {
                             """));
         }
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 新しい学生を登録する際に出身地がない時にvalidationerrorのレスポンスボティを返すこと() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.post("/students")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                     {
+                                       "name":"中田健太",
+                                       "grade":"一年生",
+                                       "birthPlace":""
+                                     }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                   "status": "400",
+                                   "message": "validation error",
+                                   "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                   "errors": [
+                                       {
+                                           "field": "birthPlace",
+                                           "message": "birthPlaceを入力してください"
+                                       }
+                                   ]
+                               }
+                            """));
+        }
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -327,4 +327,41 @@ public class studentApiIntegrationTest {
                         """));
 
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 新しい学生を登録する際に名前がない時にvalidationerrorのレスポンスボティを返すこと() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.post("/students")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                     {
+                                       "name":"",
+                                       "grade":"一年生",
+                                       "birthPlace":"福岡県"
+                                     }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                 "status": "400",
+                                 "message": "validation error",
+                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                 "errors": [
+                                     {
+                                         "field": "name",
+                                         "message": "nameを入力してください"
+                                     }
+                                 ]
+                             }
+                            """));
+        }
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -364,4 +364,42 @@ public class studentApiIntegrationTest {
                             """));
         }
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 新しい学生を登録する際に学年がない時にvalidationerrorのレスポンスボティを返すこと() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.post("/students")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                     {
+                                       "name":"中田健太",
+                                       "grade":"",
+                                       "birthPlace":"福岡県"
+                                     }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                  "status": "400",
+                                  "message": "validation error",
+                                  "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                  "errors": [
+                                      {
+                                          "field": "grade",
+                                          "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
+                                      }
+                                  ]
+                              }
+                            """));
+        }
+    }
+
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -402,4 +402,40 @@ public class studentApiIntegrationTest {
         }
     }
 
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 新しい学生を登録する際に学年が関係ない文字の時にvalidationerrorのレスポンスボティを返すこと() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.post("/students")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                     {
+                                       "name":"中田健太",
+                                       "grade":"1",
+                                       "birthPlace":"福岡県"
+                                     }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                  "status": "400",
+                                  "message": "validation error",
+                                  "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                  "errors": [
+                                      {
+                                          "field": "grade",
+                                          "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
+                                      }
+                                  ]
+                              }
+                            """));
+        }
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -475,4 +475,50 @@ public class studentApiIntegrationTest {
                             """));
         }
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 新しい学生を登録する際に全てのカラムがない時にValidationErrorのレスポンスボティを返すこと() throws Exception {
+
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.post("/students")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name":"",
+                                        "grade":"",
+                                        "birthPlace":""
+                                    }                                    
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                 "status": "400",
+                                 "message": "validation error",
+                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                 "errors": [
+                                     {
+                                         "field": "birthPlace",
+                                         "message": "birthPlaceを入力してください"
+                                     },
+                                     {
+                                         "field": "name",
+                                         "message": "nameを入力してください"
+                                     },
+                                     {
+                                         "field": "grade",
+                                         "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
+                                     }
+                                 ]
+                             }
+                            """));
+        }
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -332,7 +332,7 @@ public class studentApiIntegrationTest {
     @DataSet(value = "datasets/students.yml")
     @ExpectedDataSet(value = "datasets/students.yml")
     @Transactional
-    void 新しい学生を登録する際に名前がない時にvalidationerrorのレスポンスボティを返すこと() throws Exception {
+    void 新しい学生を登録する際に名前がない時にValidationErrorのレスポンスボティを返すこと() throws Exception {
 
         final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
 
@@ -369,7 +369,7 @@ public class studentApiIntegrationTest {
     @DataSet(value = "datasets/students.yml")
     @ExpectedDataSet(value = "datasets/students.yml")
     @Transactional
-    void 新しい学生を登録する際に学年がない時にvalidationerrorのレスポンスボティを返すこと() throws Exception {
+    void 新しい学生を登録する際に学年がない時にValidationErrorのレスポンスボティを返すこと() throws Exception {
 
         final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
 
@@ -406,7 +406,7 @@ public class studentApiIntegrationTest {
     @DataSet(value = "datasets/students.yml")
     @ExpectedDataSet(value = "datasets/students.yml")
     @Transactional
-    void 新しい学生を登録する際に学年が関係ない文字の時にvalidationerrorのレスポンスボティを返すこと() throws Exception {
+    void 新しい学生を登録する際に学年が関係ない文字の時にValidationErrorのレスポンスボティを返すこと() throws Exception {
 
         final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
 
@@ -443,7 +443,7 @@ public class studentApiIntegrationTest {
     @DataSet(value = "datasets/students.yml")
     @ExpectedDataSet(value = "datasets/students.yml")
     @Transactional
-    void 新しい学生を登録する際に出身地がない時にvalidationerrorのレスポンスボティを返すこと() throws Exception {
+    void 新しい学生を登録する際に出身地がない時にValidationErrorのレスポンスボティを返すこと() throws Exception {
 
         final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
 
@@ -475,4 +475,6 @@ public class studentApiIntegrationTest {
                             """));
         }
     }
+
+
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.koichi.assignment8.itegrationtest;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -300,5 +302,29 @@ public class studentApiIntegrationTest {
                         []
                          """));
     }
-}
 
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/studentsToRegister.yml", ignoreCols = "id")
+    @Transactional
+    void 新しい学生を登録すること() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/students")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                 {
+                                   "name":"中田健太",
+                                   "grade":"一年生",
+                                   "birthPlace":"福岡県"
+                                 }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "message": "student created"
+                        }
+                        """));
+
+    }
+}


### PR DESCRIPTION
### ◎insertStudentの結合テストの作成 

今回は、以下の5つを作成しました。
 - 新しい学生を登録する結合テスト
 - 新しい学生を登録する際に名前がない時にvalidationerrorのレスポンスボティを返す結合テスト
 - 新しい学生を登録する際に学年がない時にvalidationerrorのレスポンスボティを返す結合テスト
 - 新しい学生を登録する際に学年が関係ない文字の時にvalidationerrorのレスポンスボティを返す結合テストの作成
 - 新しい学生を登録する際に出身地がない時にvalidationerrorのレスポンスボティを返す結合テスト

ご確認よろしくお願いいたします。

### ○新しい学生を登録する結合テスト

b46e038bc99960078f4990cbbf577ba8f2bfb918

#### ○実行結果
![スクリーンショット 2024-07-21 140508](https://github.com/user-attachments/assets/6ce577a7-58b9-4970-803c-e7f4a634969e)

### ○新しい学生を登録する際に名前がない時にvalidationerrorのレスポンスボティを返す結合テスト

35a15c5e2165cb4e2625dddf18fdad0d4ff6af65

#### ○実行結果
![スクリーンショット 2024-07-21 140734](https://github.com/user-attachments/assets/5f06bc9f-032a-417e-909c-32acbba8232f)

### ○新しい学生を登録する際に学年がない時にvalidationerrorのレスポンスボティを返す結合テスト

8f468e302ea061466b096728c3b166e07f069e83

#### ○実行結果
![スクリーンショット 2024-07-21 140751](https://github.com/user-attachments/assets/247195d1-060f-4dfd-9ba0-bab37b10c581)

### ○新しい学生を登録する際に学年が関係ない文字の時にvalidationerrorのレスポンスボティを返す結合テストの作成

2bd83eb7e8d3799c8c26d0d6c5b4866a4a21d899

#### ○実行結果
![スクリーンショット 2024-07-21 140807](https://github.com/user-attachments/assets/7d49033f-5690-41d7-b9eb-6cbf4bc4dca0)

### ○新しい学生を登録する際に出身地がない時にvalidationerrorのレスポンスボティを返す結合テスト

984ed5ec4cfab0fc2b62dea527a0dc1b23b93cf1

#### ○実行結果
![スクリーンショット 2024-07-21 140820](https://github.com/user-attachments/assets/7bab5dc6-e658-4b36-a8fc-092656d3ffdf)
