### PR TITLE
ControllerのupdateStudentの結合テストの作成

### DIFF
--- a/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
+++ b/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
@@ -44,6 +44,12 @@ public class StudentControllerAdvice {
         return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }
 
+
+    /**
+     * 以下の二つについての例外処理です。
+     * 読み取り処理・登録処理・削除処理のID検索の際に文字列がリクエストされた場合
+     * 学生でクエリパラメータの検索をする際に文字列がリクエストされた場合
+     */
     @ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
     public ResponseEntity<Map<String, String>> handleMethodArgumentTypeMismatchException(
             MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
@@ -51,7 +57,7 @@ public class StudentControllerAdvice {
                 "timestamp", ZonedDateTime.now().format(formatter),
                 "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
                 "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
-                "message", "gradeは、1~4のどれかを入力してください",
+                "message", "IDまたは学年を入力する際は、半角の数字で入力してください",
                 "path", request.getRequestURI());
         return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
+++ b/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
@@ -3,6 +3,7 @@ package com.koichi.assignment8.excption;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingPathVariableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -69,6 +70,22 @@ public class StudentControllerAdvice {
     @ExceptionHandler(value = MissingPathVariableException.class)
     public ResponseEntity<Map<String, String>> handleMissingPathVariableException(
             MissingPathVariableException ex, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().format(formatter),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", "学生のIDを入力してください",
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 更新処理・削除処理の際に全学生がリクエストされた場合の
+     * 例外処理です。
+     */
+    @ExceptionHandler(value = HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<Map<String, String>> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException ex, HttpServletRequest request) {
         Map<String, String> body = Map.of(
                 "timestamp", ZonedDateTime.now().format(formatter),
                 "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),

--- a/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
+++ b/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingPathVariableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -44,7 +45,6 @@ public class StudentControllerAdvice {
         return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }
 
-
     /**
      * 以下の二つについての例外処理です。
      * 読み取り処理・登録処理・削除処理のID検索の際に文字列がリクエストされた場合
@@ -58,6 +58,22 @@ public class StudentControllerAdvice {
                 "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
                 "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
                 "message", "IDまたは学年を入力する際は、半角の数字で入力してください",
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+    }
+
+    /**
+     * 更新処理・削除処理のID検索の際空白がリクエストされた場合の
+     * 例外処理です。
+     */
+    @ExceptionHandler(value = MissingPathVariableException.class)
+    public ResponseEntity<Map<String, String>> handleMissingPathVariableException(
+            MissingPathVariableException ex, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().format(formatter),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                "message", "学生のIDを入力してください",
                 "path", request.getRequestURI());
         return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -321,7 +321,7 @@ public class studentApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isCreated())
                 .andExpect(MockMvcResultMatchers.content().json("""
                         {
-                             "message": "student created"
+                            "message": "student created"
                          }
                         """));
 
@@ -387,15 +387,15 @@ public class studentApiIntegrationTest {
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                                 "status": "400",
-                                 "message": "validation error",
-                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                                 "errors": [
-                                     {
-                                         "field": "grade",
-                                         "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
-                                     }
-                                 ]
+                                "status": "400",
+                                "message": "validation error",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "errors": [
+                                    {
+                                        "field": "grade",
+                                        "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
+                                    }
+                                ]
                             }
                             """));
         }
@@ -424,15 +424,15 @@ public class studentApiIntegrationTest {
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                                 "status": "400",
-                                 "message": "validation error",
-                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                                 "errors": [
-                                     {
-                                         "field": "grade",
-                                         "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
-                                     }
-                                 ]
+                                "status": "400",
+                                "message": "validation error",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "errors": [
+                                    {
+                                        "field": "grade",
+                                        "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
+                                    }
+                                ]
                             }
                             """));
         }
@@ -461,15 +461,15 @@ public class studentApiIntegrationTest {
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                                 "status": "400",
-                                 "message": "validation error",
-                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                                 "errors": [
-                                     {
-                                         "field": "birthPlace",
-                                         "message": "birthPlaceを入力してください"
-                                     }
-                                 ]
+                                "status": "400",
+                                "message": "validation error",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "errors": [
+                                    {
+                                        "field": "birthPlace",
+                                        "message": "birthPlaceを入力してください"
+                                    }
+                                ]
                             }
                             """));
         }
@@ -499,24 +499,24 @@ public class studentApiIntegrationTest {
                     .andExpect(MockMvcResultMatchers.status().isBadRequest())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                                 "status": "400",
-                                 "message": "validation error",
-                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                                 "errors": [
-                                     {
-                                         "field": "birthPlace",
-                                         "message": "birthPlaceを入力してください"
-                                     },
-                                     {
-                                         "field": "name",
-                                         "message": "nameを入力してください"
-                                     },
-                                     {
-                                         "field": "grade",
-                                         "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
-                                     }
-                                 ]
-                             }
+                                "status": "400",
+                                "message": "validation error",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "errors": [
+                                    {
+                                        "field": "name",
+                                        "message": "nameを入力してください"
+                                    },
+                                    {
+                                        "field": "grade",
+                                        "message": "有効な学年を指定してください（一年生, 二年生, 三年生のいずれか）。"
+                                    },
+                                    {
+                                        "field": "birthPlace",
+                                        "message": "birthPlaceを入力してください"
+                                    }
+                                ]
+                            }
                             """));
         }
     }
@@ -539,10 +539,9 @@ public class studentApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""
                         {
-                              "message": "Student updated"
+                             "message": "Student updated"
                         }
                         """));
-
     }
 
     @Test
@@ -568,14 +567,13 @@ public class studentApiIntegrationTest {
                     .andExpect(MockMvcResultMatchers.status().isNotFound())
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
-                                 "message": "student not found",
-                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                                 "error": "Not Found",
-                                 "path": "/students/0",
-                                 "status": "404"
-                             }
+                                "path": "/students/0",
+                                "status": "404",
+                                "message": "student not found",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "error": "Not Found"
+                            }
                             """));
-
         }
     }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -676,4 +676,40 @@ public class studentApiIntegrationTest {
         }
     }
 
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 学生のデータを更新する際に名前がない場合ValidationErrorのレスポンスボティを返すこと() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.patch("/students/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name":"",
+                                        "grade":"二年生",
+                                        "birthPlace":"福岡県"
+                                    }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "status": "400",
+                                "message": "validation error",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "errors": [
+                                    {
+                                        "field": "name",
+                                        "message": "nameを入力してください"
+                                    }
+                                ]
+                            }
+                            """));
+        }
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -609,4 +609,37 @@ public class studentApiIntegrationTest {
                             """));
         }
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 学生のデータを更新する際にリクエストされたIDが空白の場合handleMissingPathVariableExceptionのレスポンスボティが返却されること() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.patch("/students/ ")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name":"城野健一",
+                                        "grade":"二年生",
+                                        "birthPlace":"福岡県"
+                                    }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "error": "Bad Request",
+                                "path": "/students/%20",
+                                "status": "400",
+                                "message": "学生のIDを入力してください"
+                            }
+                            """));
+        }
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -712,4 +712,41 @@ public class studentApiIntegrationTest {
                             """));
         }
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 学生のデータを更新する際に学年がない時にValidationErrorのレスポンスボティを返すこと() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.patch("/students/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name":"城野健一",
+                                        "grade":"",
+                                        "birthPlace":"福岡県"
+                                    }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "status": "400",
+                                "message": "validation error",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "errors": [
+                                    {
+                                        "field": "grade",
+                                        "message": "有効な学年を指定してください（一年生, 二年生, 三年生,卒業生のいずれか）。"
+                                    }
+                                ]
+                            }
+                            """));
+        }
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -787,4 +787,40 @@ public class studentApiIntegrationTest {
         }
     }
 
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 学生のデータを更新する際に出身地がない時にValidationErrorのレスポンスボティを返すこと() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.patch("/students/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name":"城野健一",
+                                        "grade":"二年生",
+                                        "birthPlace":""
+                                    }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "status": "400",
+                                "message": "validation error",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "errors": [
+                                    {
+                                        "field": "birthPlace",
+                                        "message": "birthPlaceを入力してください"
+                                    }
+                                ]
+                            }
+                            """));
+        }
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -749,4 +749,42 @@ public class studentApiIntegrationTest {
                             """));
         }
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 学生のデータを更新する際に学年が関係ない文字の時にValidationErrorのレスポンスボティを返すこと() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.patch("/students/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name":"城野健一",
+                                        "grade":"1",
+                                        "birthPlace":"福岡県"
+                                    }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "status": "400",
+                                "message": "validation error",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "errors": [
+                                    {
+                                        "field": "grade",
+                                        "message": "有効な学年を指定してください（一年生, 二年生, 三年生,卒業生のいずれか）。"
+                                    }
+                                ]
+                            }
+                            """));
+        }
+    }
+
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -544,4 +544,38 @@ public class studentApiIntegrationTest {
                         """));
 
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 学生のデータを更新する際に該当するIDの学生がいない場合StudentNotFoundExceptionのレスポンスボティが返却されること() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.patch("/students/0")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name":"城野健一",
+                                        "grade":"二年生",
+                                        "birthPlace":"福岡県"
+                                    }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isNotFound())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                 "message": "student not found",
+                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                 "error": "Not Found",
+                                 "path": "/students/0",
+                                 "status": "404"
+                             }
+                            """));
+
+        }
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -642,4 +642,38 @@ public class studentApiIntegrationTest {
                             """));
         }
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 学生のデータを更新する際に全学生をリクエストされたの場合handleHttpRequestMethodNotSupportedExceptionのレスポンスボティが返却されること() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.patch("/students")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name":"城野健一",
+                                        "grade":"二年生",
+                                        "birthPlace":"福岡県"
+                                    }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "status": "400",
+                                "message": "学生のIDを入力してください",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "error": "Bad Request",
+                                "path": "/students"
+                            }
+                            """));
+        }
+    }
+
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -823,4 +823,49 @@ public class studentApiIntegrationTest {
                             """));
         }
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 学生のデータを更新する際に全てのカラムがない時にValidationErrorのレスポンスボティを返すこと() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.patch("/students/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name":"",
+                                        "grade":"",
+                                        "birthPlace":""
+                                    }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "status": "400",
+                                "message": "validation error",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "errors": [
+                                    {
+                                        "field": "birthPlace",
+                                        "message": "birthPlaceを入力してください"
+                                    },
+                                    {
+                                        "field": "grade",
+                                        "message": "有効な学年を指定してください（一年生, 二年生, 三年生,卒業生のいずれか）。"
+                                    },
+                                    {
+                                        "field": "name",
+                                        "message": "nameを入力してください"
+                                    }
+                                ]
+                            }
+                            """));
+        }
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -303,7 +303,6 @@ public class studentApiIntegrationTest {
                          """));
     }
 
-
     @Test
     @DataSet(value = "datasets/students.yml")
     @ExpectedDataSet(value = "datasets/studentsToRegister.yml", ignoreCols = "id")
@@ -520,5 +519,29 @@ public class studentApiIntegrationTest {
                              }
                             """));
         }
+    }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/studentsToRenewing.yml", ignoreCols = "id")
+    @Transactional
+    void IDに該当する学生のデータを更新出来ること() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/students/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "name":"城野健一",
+                                    "grade":"二年生",
+                                    "birthPlace":"福岡県"
+                                }
+                                """))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                              "message": "Student updated"
+                        }
+                        """));
+
     }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -601,7 +601,7 @@ public class studentApiIntegrationTest {
                     .andExpect(MockMvcResultMatchers.content().json("""
                             {
                                 "status": "400",
-                                "message": "IDまたは学年は半角の数字で入力してください",
+                                "message": "IDまたは学年を入力する際は、半角の数字で入力してください",
                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
                                 "error": "Bad Request",
                                 "path": "/students/%E3%81%82"

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -261,7 +261,7 @@ public class studentApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/students.yml")
     @Transactional
-    void 学年でクエリパラメータの検索を使用する際に文字列を入力した時にMethodArgumentTypeMismatchExceptionのレスポンスボティが返却されること() throws Exception {
+    void 学年でクエリパラメータの検索を使用する際に文字列を入力した時にhandleMethodArgumentTypeMismatchExceptionのレスポンスボティが返却されること() throws Exception {
 
         final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
 
@@ -273,7 +273,7 @@ public class studentApiIntegrationTest {
                             {
                                 "path": "/students",
                                 "status": "400",
-                                "message": "gradeは、1~4のどれかを入力してください",
+                                "message": "IDまたは学年を入力する際は、半角の数字で入力してください",
                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
                                 "error": "Bad Request"
                             }
@@ -572,6 +572,39 @@ public class studentApiIntegrationTest {
                                 "message": "student not found",
                                 "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
                                 "error": "Not Found"
+                            }
+                            """));
+        }
+    }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void 学生のデータを更新する際にリクエストされたIDが文字列の場合handleMethodArgumentTypeMismatchExceptionのレスポンスボティが返却されること() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.patch("/students/あ")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "name":"城野健一",
+                                        "grade":"二年生",
+                                        "birthPlace":"福岡県"
+                                    }
+                                    """))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "status": "400",
+                                "message": "IDまたは学年は半角の数字で入力してください",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+                                "error": "Bad Request",
+                                "path": "/students/%E3%81%82"
                             }
                             """));
         }


### PR DESCRIPTION
### ◎ControllerのupdateStudentの結合テストの作成

今回は以下の10個について実装しました。
 - IDに該当する学生のデータを更新出来る結合テスト
 - 学生のデータを更新する際に該当するIDの学生がいない場合StudentNotFoundExceptionのレスポンスボティが返却される結合テスト 
 - 学生のデータを更新する際にリクエストされたIDが文字列の場合handleMethodArgumentTypeMismatchExceptionのレスポンスボティが返却される結合テスト 
 - 学生のデータを更新する際にリクエストされたIDが空白の場合handleMissingPathVariableExceptionのレスポンスボディが返却される結合テスト 
 - 学生のデータを更新する際に全学生をリクエストされたの場合handleHttpRequestMethodNotSupportedExceptionのレスポンスボティが返却される結合テスト 
 - 学生のデータを更新する際に名前がない場合ValidationErrorのレスポンスボティを返す結合テスト
 - 学生のデータを更新する際に学年がない時にValidationErrorのレスポンスボティを返す結合テスト
 - 学生のデータを更新する際に学年が関係ない文字の時にValidationErrorのレスポンスボティを返す結合テスト 
 - 学生のデータを更新する際に出身地がない時にValidationErrorのレスポンスボティを返す結合テスト 
 - 学生のデータを更新する際に全てのカラムがない時にValidationErrorのレスポンスボティを返す結合テスト

よろしくお願いいたします。


### ○IDに該当する学生のデータを更新出来る結合テスト
7566b465a313415ee76587b0fd46754aed68ad75

#### ○実行結果
![スクリーンショット 2024-07-24 094627](https://github.com/user-attachments/assets/0293b333-66af-4ec6-8dd6-21dfdd0b1d5a)

### ○学生のデータを更新する際に該当するIDの学生がいない場合StudentNotFoundExceptionのレスポンスボティが返却される結合テスト 
5053c4b032863a0f3f080c21bd2fb6c0255fdaaa

#### ○実行結果
![スクリーンショット 2024-07-24 094643](https://github.com/user-attachments/assets/76bc6130-73ae-49b6-ab55-91ddebe7de2e)

### ○学生のデータを更新する際にリクエストされたIDが文字列の場合handleMethodArgumentTypeMismatchExceptionのレスポンスボティが返却される結合テスト 
ccf7792e785569fdc03875f2dca1841f92bbc1fb

 - レスポンスボティのエラーメッセージが間違っていましたので、下記のコミットで修正していました。
 
6aaba63f7e0f84b14c815f1b39012ef4f7664b65

#### ○実行結果
![スクリーンショット 2024-07-24 094809](https://github.com/user-attachments/assets/d63fc6d5-67f2-4e1c-822c-5346f952d32e)


### ○学生のデータを更新する際にリクエストされたIDが空白の場合handleMissingPathVariableExceptionのレスポンスボディが返却される結合テスト 
78f05664e1d55614a547db2cfe53d47d5bab3d22


#### ○実行結果
![スクリーンショット 2024-07-24 095027](https://github.com/user-attachments/assets/6e753ab2-a803-487e-8bbd-648487512e9c)

### ○学生のデータを更新する際に全学生をリクエストされたの場合handleHttpRequestMethodNotSupportedExceptionのレスポンスボティが返却される結合テスト 
7c6638a39668778149e5de7ba0d97ce5df7e6fa5

#### ○実行結果
![スクリーンショット 2024-07-24 095044](https://github.com/user-attachments/assets/c8c4b600-a3a9-4513-ab9c-1cd4bf1ad26b)

### ○学生のデータを更新する際に名前がない場合ValidationErrorのレスポンスボティを返す結合テスト
3c782248c41c04d7e05fd03cfeef437cf7b7770f

#### ○実行結果
![スクリーンショット 2024-07-24 095058](https://github.com/user-attachments/assets/7e1ead16-fd60-45f5-8210-b7361f52e51b)

### ○学生のデータを更新する際に学年がない時にValidationErrorのレスポンスボティを返す結合テスト
cd022441ef7d75a0d21d8ca066c5018678946ebe

#### ○実行結果
![スクリーンショット 2024-07-24 095114](https://github.com/user-attachments/assets/54fb7862-0025-4a9c-89ff-7aa113764f54)

### ○学生のデータを更新する際に学年が関係ない文字の時にValidationErrorのレスポンスボティを返す結合テスト
d39748960c912d46ea6c0fcc789eafd2d92bd04d

#### ○実行結果
![スクリーンショット 2024-07-24 102821](https://github.com/user-attachments/assets/55684342-bd76-4738-8847-d5d6098118a0)

### ○学生のデータを更新する際に出身地がない時にValidationErrorのレスポンスボティを返す結合テスト
a744847c0e0ade7e7f173a5536937ec40363dc7c

#### ○実行結果
![スクリーンショット 2024-07-24 102835](https://github.com/user-attachments/assets/5e1d15c8-0c21-49bf-8691-3a397c29a824)

### ○学生のデータを更新する際に全てのカラムがない時にValidationErrorのレスポンスボティを返す結合テスト
2a389bf6517cd53384b1bc92e8429c3335577ff9

#### ○実行結果
![スクリーンショット 2024-07-24 102850](https://github.com/user-attachments/assets/e287b7af-8de8-4a89-8c71-bc35b4f208b8)
