### PR TITLE
ControllerのfindByIdの結合テストの追加作成

### DIFF
--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -93,6 +93,29 @@ public class studentApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/students.yml")
     @Transactional
+    void 学生のデータを取得する際にIDが空白の場合handleMissingPathVariableExceptionのレスポンスボティが返却されること() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+            mockMvc.perform(MockMvcRequestBuilders.get("/students/ "))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "message": "学生のIDを入力してください",
+                                "status": "400",
+                                "path": "/students/%20",
+                                "error": "Bad Request",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］"
+                            }                                                  
+                            """));
+        }
+    }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
     void 全ての学生を取得すること() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/students"))
                 .andExpect(MockMvcResultMatchers.status().isOk())

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -70,6 +70,29 @@ public class studentApiIntegrationTest {
     @Test
     @DataSet(value = "datasets/students.yml")
     @Transactional
+    void 学生のデータを取得する際にIDが文字列の場合handleMethodArgumentTypeMismatchExceptionのレスポンスボティが返却されること() throws Exception {
+
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+            mockMvc.perform(MockMvcRequestBuilders.get("/students/あ"))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                    .andExpect(MockMvcResultMatchers.content().json("""
+                            {
+                                "message": "IDまたは学年を入力する際は、半角の数字で入力してください",
+                                "status": "400",
+                                "path": "/students/%E3%81%82",
+                                "error": "Bad Request",
+                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］"
+                            }                                                     
+                            """));
+        }
+    }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @Transactional
     void 全ての学生を取得すること() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/students"))
                 .andExpect(MockMvcResultMatchers.status().isOk())


### PR DESCRIPTION
### ◎ControllerのfindByIdの結合テストの追加作成 

今回は、以下の２つについて作成しました。
 - 学生のデータを取得する際にIDが文字列の場合handleMethodArgumentTypeMismatchExceptionのレスポンスボディを返却される結合テスト
 -  学生のデータを取得する際にIDが空白の場合handleMissingPathVariableExceptionのレスポンスボティが返却される結合テスト
 
ご確認よろしくお願いいたします。

### ○学生のデータを取得する際にIDが文字列の場合handleMethodArgumentTypeMismatchExceptionのレスポンスボディを返却される結合テスト

b102f3ac78375f90693ca4b8faeea75e687b00df

#### ○実行結果
![スクリーンショット 2024-07-25 211105](https://github.com/user-attachments/assets/8e4c0236-2c26-4595-85b7-49932ded33b9)


### ○学生のデータを取得する際にIDが空白の場合handleMissingPathVariableExceptionのレスポンスボティが返却される結合テスト

 6a3fbaf9096a856eaff98f7368d8385f7cf50e2d

#### ○実行結果
![スクリーンショット 2024-07-25 212315](https://github.com/user-attachments/assets/bf7b0595-cb7d-4c49-b6fc-163ff673cd2d)
