### PR TITLE
@ParameterizedTestとjsonPathを使った結合テストに修正

### DIFF
--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -48,22 +48,40 @@ public class studentApiIntegrationTest {
 
     @ParameterizedTest
     @CsvSource({
+            "status,404",
             "path,/students/999",
+            "error,Not Found",
             "timestamp,2024/01/01 T00:00:00+0900［Asia/Tokyo］",
             "message,student not found",
-            "status,404"
+            "status,400",
+            "path,/students/%E3%81%82",
+            "error,Bad Request",
+            "timestamp,2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+            "message,IDまたは学年を入力する際は、半角の数字で入力してください"
     })
     @DataSet(value = "datasets/students.yml")
     @Transactional
-    void IDに該当する学生がいない時にStudentNotFoundExceptionのレスポンスボディが返却されること(String key, String value) throws Exception {
+    void IDに該当する学生を取得する際の例外処理のレスポンスを返すこと(String key, String value) throws Exception {
 
         final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
 
         try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+
             mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
-            mockMvc.perform(MockMvcRequestBuilders.get("/students/999"))
-                    .andExpect(MockMvcResultMatchers.status().isNotFound())
-                    .andExpect(MockMvcResultMatchers.jsonPath("$." + key).value(value));
+
+            //IDに該当する学生がいない時にStudentNotFoundExceptionのレスポンスボディが返却される
+            if (key.equals("status") && value.equals("404")) {
+                mockMvc.perform(MockMvcRequestBuilders.get("/students/999"))
+                        .andExpect(MockMvcResultMatchers.status().isNotFound())
+                        .andExpect(MockMvcResultMatchers.jsonPath("$.." + key).value(value));
+            }
+
+            //学生のデータを取得する際にIDが文字列の場合handleMethodArgumentTypeMismatchExceptionのレスポンスボティが返却される
+            if (key.equals("status") && value.equals("400")) {
+                mockMvc.perform(MockMvcRequestBuilders.get("/students/あ"))
+                        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                        .andExpect(MockMvcResultMatchers.jsonPath("$.." + key).value(value));
+            }
         }
     }
 

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -48,13 +48,13 @@ public class studentApiIntegrationTest {
 
     @ParameterizedTest
     @CsvSource({
-            "'/students/999',404,'{\"error\":\"Not Found\",\"timestamp\":\"2024/01/01 T00:00:00+0900［Asia/Tokyo］\",\"message\":\"student not found\",\"status\":\"404\",\"path\":\"/students/999\"}'",
-            "'/students/あ',400,'{\"error\":\"Bad Request\",\"timestamp\":\"2024/01/01 T00:00:00+0900［Asia/Tokyo］\",\"message\":\"IDまたは学年を入力する際は、半角の数字で入力してください\",\"status\":\"400\",\"path\":\"/students/%E3%81%82\"}'",
-            "'/students/ ',400,'{\"error\":\"Bad Request\",\"timestamp\":\"2024/01/01 T00:00:00+0900［Asia/Tokyo］\",\"message\":\"学生のIDを入力してください\",\"status\":\"400\",\"path\":\"/students/%20\"}'"
+            "'/students/999','{\"error\":\"Not Found\",\"timestamp\":\"2024/01/01 T00:00:00+0900［Asia/Tokyo］\",\"message\":\"student not found\",\"status\":\"404\",\"path\":\"/students/999\"}'",
+            "'/students/あ','{\"error\":\"Bad Request\",\"timestamp\":\"2024/01/01 T00:00:00+0900［Asia/Tokyo］\",\"message\":\"IDまたは学年を入力する際は、半角の数字で入力してください\",\"status\":\"400\",\"path\":\"/students/%E3%81%82\"}'",
+            "'/students/ ','{\"error\":\"Bad Request\",\"timestamp\":\"2024/01/01 T00:00:00+0900［Asia/Tokyo］\",\"message\":\"学生のIDを入力してください\",\"status\":\"400\",\"path\":\"/students/%20\"}'"
     })
     @DataSet(value = "datasets/students.yml")
     @Transactional
-    void IDに該当する学生を取得する際の例外処理のレスポンスを返すこと(String requestPath, int statusCode, String response) throws Exception {
+    void IDに該当する学生を取得する際の例外処理のレスポンスを返すこと(String requestPath, String response) throws Exception {
 
         final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
 
@@ -63,7 +63,6 @@ public class studentApiIntegrationTest {
             mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
 
             mockMvc.perform(MockMvcRequestBuilders.get(requestPath))
-                    .andExpect(MockMvcResultMatchers.status().is(statusCode))
                     .andExpect(MockMvcResultMatchers.content().json(response));
         }
     }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -4,6 +4,8 @@ import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,10 +46,16 @@ public class studentApiIntegrationTest {
                         """));
     }
 
-    @Test
+    @ParameterizedTest
+    @CsvSource({
+            "path,/students/999",
+            "timestamp,2024/01/01 T00:00:00+0900［Asia/Tokyo］",
+            "message,student not found",
+            "status,404"
+    })
     @DataSet(value = "datasets/students.yml")
     @Transactional
-    void IDに該当する学生がいない時にStudentNotFoundExceptionのレスポンスボティが返却されること() throws Exception {
+    void IDに該当する学生がいない時にStudentNotFoundExceptionのレスポンスボディが返却されること(String key, String value) throws Exception {
 
         final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
 
@@ -55,15 +63,7 @@ public class studentApiIntegrationTest {
             mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
             mockMvc.perform(MockMvcRequestBuilders.get("/students/999"))
                     .andExpect(MockMvcResultMatchers.status().isNotFound())
-                    .andExpect(MockMvcResultMatchers.content().json("""
-                            {
-                                "error": "Not Found",
-                                "path": "/students/999",
-                                "status": "404",
-                                "timestamp": "2024/01/01 T00:00:00+0900［Asia/Tokyo］",
-                                "message": "student not found"
-                            }                                                      
-                            """));
+                    .andExpect(MockMvcResultMatchers.jsonPath("$." + key).value(value));
         }
     }
 


### PR DESCRIPTION
### ◎@ParameterizedTestとjsonPathを使った結合テストに修正

前々回のPRの際に、PRの際に@ParameterizedTestを使うとコードがきれいになると
アドバイスを頂きましたので、実装しました。

 - 前々回のPRのアドバイス
https://github.com/mizoguchi-kouichi/assignment8/pull/25#pullrequestreview-2196890739

実装できましたが、コードの書き方が合っているか不安だったので
ControllerのfindByIdの結合テストにのみ実装しております。

確認してもらってOKがもらえたら、他のメソッドも修正していく形にしていきます。
よろしくお願いいたします。

### ○IDに該当する学生がいない時にStudentNotFoundExceptionのレスポンスボディが返却されることのテストを@ParameterizedTestに変更

c249e012730ee016da47413b1a874a09ddb84a64

#### ○実行結果

![スクリーンショット 2024-07-26 210751](https://github.com/user-attachments/assets/791ea9f6-c5c6-4d7c-a08e-a27f9d2c103c)


