### PR TITLE
学生の学年を進級させる結合テストの作成

### DIFF
--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -359,4 +359,18 @@ public class studentApiIntegrationTest {
         }
     }
 
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/gradeAdvancement.yml", ignoreCols = "id")
+    @Transactional
+    void 学生の学年を進級させること() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.patch("/students/grade:batchUpdate"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                             "message": "Grade updated"
+                        }
+                        """));
+    }
 }


### PR DESCRIPTION
### ◎学生の学年を進級させる結合テストの作成

今回は、controllerのupdateGradeの結合テストの作成をしました。
ご確認よろしくお願いいたします。

### ○学生の学年を進級させる結合テストの作成
9fa20b3c0d819dabae809e704de0732d0b208fd5

#### ○実行結果
![スクリーンショット 2024-08-05 201328](https://github.com/user-attachments/assets/5f3c1aae-c32f-4837-9733-fe6d7839a490)

