### PR TITLE
controllerのdeleteStudentの結合テストの作成

### DIFF
--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -373,4 +373,19 @@ public class studentApiIntegrationTest {
                         }
                         """));
     }
+
+    @Test
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/studentsToRemoved.yml")
+    @Transactional
+    void IDに該当する学生のデータを削除出来ること() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/students/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            "message": "Student deleted"
+                        }
+                        """));
+    }
 }

--- a/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
+++ b/src/test/java/com/koichi/assignment8/itegrationtest/studentApiIntegrationTest.java
@@ -388,4 +388,25 @@ public class studentApiIntegrationTest {
                         }
                         """));
     }
+
+    @ParameterizedTest
+    @CsvSource({
+            "'/students/999','{\"error\":\"Not Found\",\"timestamp\":\"2024/01/01 T00:00:00+0900［Asia/Tokyo］\",\"message\":\"student not found\",\"status\":\"404\",\"path\":\"/students/999\"}'",
+            "'/students/あ','{\"error\":\"Bad Request\",\"timestamp\":\"2024/01/01 T00:00:00+0900［Asia/Tokyo］\",\"message\":\"IDまたは学年を入力する際は、半角の数字で入力してください\",\"status\":\"400\",\"path\":\"/students/%E3%81%82\"}'",
+            "'/students/ ','{\"error\":\"Bad Request\",\"timestamp\":\"2024/01/01 T00:00:00+0900［Asia/Tokyo］\",\"message\":\"学生のIDを入力してください\",\"status\":\"400\",\"path\":\"/students/%20\"}'"
+    })
+    @DataSet(value = "datasets/students.yml")
+    @ExpectedDataSet(value = "datasets/students.yml")
+    @Transactional
+    void IDに該当する学生のデータを削除する際の例外処理のレスポンスを返却すること(String path, String response) throws Exception {
+        
+        final ZonedDateTime fixedClock = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneId.of("Asia/Tokyo"));
+
+        try (MockedStatic<ZonedDateTime> mockClock = Mockito.mockStatic(ZonedDateTime.class)) {
+            mockClock.when(ZonedDateTime::now).thenReturn(fixedClock);
+
+            mockMvc.perform(MockMvcRequestBuilders.delete(path))
+                    .andExpect(MockMvcResultMatchers.content().json(response));
+        }
+    }
 }


### PR DESCRIPTION
### ◎controllerのdeleteStudentの結合テストの作成

今回は以下の二つを作成しまいました。
 - IDに該当する学生のデータを削除出来る結合テスト
 - IDに該当する学生のデータを削除する際の例外処理のレスポンスを返却する結合テスト
 
ご確認よろしくお願いいたします。

### ○IDに該当する学生のデータを削除出来る結合テスト
749c485a38b2d0e0c97f496195d405f9b451091a

#### ○実行結果
![スクリーンショット 2024-08-07 115141](https://github.com/user-attachments/assets/63ffb009-d068-4125-bfc0-bae7d9f56c64)

### ○IDに該当する学生のデータを削除する際の例外処理のレスポンスを返却する結合テスト
6df0fbce6e20d7f376651d4445437ede18bfa49d

#### ○実行結果
![スクリーンショット 2024-08-07 115121](https://github.com/user-attachments/assets/7f6d21fa-6f01-4909-b93f-207fb17e1d5e)