### PR TITLE
findByIdにてtrycatch文でMethodArgumentTypeMismatchExceptionを投げるように修正

### DIFF
--- a/src/main/java/com/koichi/assignment8/controller/StudentController.java
+++ b/src/main/java/com/koichi/assignment8/controller/StudentController.java
@@ -4,6 +4,7 @@ import com.koichi.assignment8.controller.request.StudentPostRequest;
 import com.koichi.assignment8.controller.request.StudentUpdateRequest;
 import com.koichi.assignment8.controller.response.StudentResponse;
 import com.koichi.assignment8.entity.Student;
+import com.koichi.assignment8.excption.MethodArgumentTypeMismatchException;
 import com.koichi.assignment8.service.StudentService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -34,8 +35,14 @@ public class StudentController {
      * 指定したidのstudentのデータを全て取得します。
      */
     @GetMapping("/students/{id}")
-    public Student findById(@PathVariable("id") Integer id) {
-        return studentService.findStudent(id);
+    public Student findById(@PathVariable("id") String id) {
+        try {
+            int intTypeConvertedId = Integer.parseInt(id);
+            return studentService.findStudent(intTypeConvertedId);
+        } catch (NumberFormatException e) {
+            throw new MethodArgumentTypeMismatchException("IDが文字列になっています");
+        }
+
     }
 
     /**

--- a/src/main/java/com/koichi/assignment8/controller/StudentController.java
+++ b/src/main/java/com/koichi/assignment8/controller/StudentController.java
@@ -36,13 +36,13 @@ public class StudentController {
      */
     @GetMapping("/students/{id}")
     public Student findById(@PathVariable("id") String id) {
+        int intTypeConvertedId;
         try {
-            int intTypeConvertedId = Integer.parseInt(id);
-            return studentService.findStudent(intTypeConvertedId);
+            intTypeConvertedId = Integer.parseInt(id);
         } catch (NumberFormatException e) {
             throw new MethodArgumentTypeMismatchException("IDは数字で入力してください");
         }
-
+        return studentService.findStudent(intTypeConvertedId);
     }
 
     /**

--- a/src/main/java/com/koichi/assignment8/controller/StudentController.java
+++ b/src/main/java/com/koichi/assignment8/controller/StudentController.java
@@ -40,7 +40,7 @@ public class StudentController {
             int intTypeConvertedId = Integer.parseInt(id);
             return studentService.findStudent(intTypeConvertedId);
         } catch (NumberFormatException e) {
-            throw new MethodArgumentTypeMismatchException("IDが文字列になっています");
+            throw new MethodArgumentTypeMismatchException("IDは数字で入力してください");
         }
 
     }

--- a/src/main/java/com/koichi/assignment8/excption/MethodArgumentTypeMismatchException.java
+++ b/src/main/java/com/koichi/assignment8/excption/MethodArgumentTypeMismatchException.java
@@ -1,0 +1,8 @@
+package com.koichi.assignment8.excption;
+
+public class MethodArgumentTypeMismatchException extends RuntimeException {
+
+    public MethodArgumentTypeMismatchException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
+++ b/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingPathVariableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -52,15 +51,15 @@ public class StudentControllerAdvice {
      * 学生でクエリパラメータの検索をする際に文字列がリクエストされた場合
      */
     @ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<Map<String, String>> handleMethodArgumentTypeMismatchException(
-            MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+    public ResponseEntity<Map<String, String>> handleUserNotFoundException(
+            MethodArgumentTypeMismatchException e, HttpServletRequest request) {
         Map<String, String> body = Map.of(
                 "timestamp", ZonedDateTime.now().format(formatter),
-                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
-                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
-                "message", "IDまたは学年を入力する際は、半角の数字で入力してください",
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
                 "path", request.getRequestURI());
-        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
     }
 
     /**

--- a/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
+++ b/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
@@ -55,11 +55,11 @@ public class StudentControllerAdvice {
             MethodArgumentTypeMismatchException e, HttpServletRequest request) {
         Map<String, String> body = Map.of(
                 "timestamp", ZonedDateTime.now().format(formatter),
-                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
-                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
                 "message", e.getMessage(),
                 "path", request.getRequestURI());
-        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
+        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }
 
     /**

--- a/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
+++ b/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
@@ -51,7 +51,7 @@ public class StudentControllerAdvice {
      * 学生でクエリパラメータの検索をする際に文字列がリクエストされた場合
      */
     @ExceptionHandler(value = MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<Map<String, String>> handleUserNotFoundException(
+    public ResponseEntity<Map<String, String>> handleMethodArgumentTypeMismatchException(
             MethodArgumentTypeMismatchException e, HttpServletRequest request) {
         Map<String, String> body = Map.of(
                 "timestamp", ZonedDateTime.now().format(formatter),

--- a/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
+++ b/src/main/java/com/koichi/assignment8/excption/StudentControllerAdvice.java
@@ -5,7 +5,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.MissingPathVariableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -58,22 +57,6 @@ public class StudentControllerAdvice {
                 "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
                 "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
                 "message", e.getMessage(),
-                "path", request.getRequestURI());
-        return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
-    }
-
-    /**
-     * 更新処理・削除処理のID検索の際空白がリクエストされた場合の
-     * 例外処理です。
-     */
-    @ExceptionHandler(value = MissingPathVariableException.class)
-    public ResponseEntity<Map<String, String>> handleMissingPathVariableException(
-            MissingPathVariableException ex, HttpServletRequest request) {
-        Map<String, String> body = Map.of(
-                "timestamp", ZonedDateTime.now().format(formatter),
-                "status", String.valueOf(HttpStatus.BAD_REQUEST.value()),
-                "error", HttpStatus.BAD_REQUEST.getReasonPhrase(),
-                "message", "学生のIDを入力してください",
                 "path", request.getRequestURI());
         return new ResponseEntity(body, HttpStatus.BAD_REQUEST);
     }


### PR DESCRIPTION
### ◎findByIdにてtrycatch文でMethodArgumentTypeMismatchExceptionを投げるように修正

前回のPRの提出の際に、以下の質問について
「それぞれのCLOUD処理でtry-catch文を使ってオリジナル例外を出しわけを行ってください」と回答がありましたので、今回実装してみました。

よろしくお願いいたします。

 - 前回のPRのURL
https://github.com/mizoguchi-kouichi/assignment8/pull/31
> MethodArgumentTypeMismatchExceptionのエラーを「IDまたは学年を入力する際は、半角の数字で入力してください」という具体的な文にしましたが、
このアプローチだと他のCLOUD処理においてもも同じ例外レスポンスが発生した際に誤ったメッセージが出力される可能性があるとおもいましたので、教えて頂きたいです！


### ○findByIdにてtrycatch文でMethodArgumentTypeMismatchExceptionを投げるように修正
c7c40476ba0f11536201bf694b9b0affa787aa3b

今までのMethodArgumentTypeMismatchExceptionはspringの例外処理の一つだったので、try-catch文ではキャッチできない事が分かりました。

try-catch文を使ってJAVAの既存の例外処理をキャッチをして、自作のMethodArgumentTypeMismatchExceptionを投げるような形にしたかったので、

①Id（文字列）をリクエストする

②型変換でIdを文字列からint型に変換して
成功したら、studentServiceclassに返す
失敗したら、NumberFormatExceptionをcatchして、
自作のMethodArgumentTypeMismatchExceptionを投げる

という流れになるようにコードを書きました。

#### ○実行結果

![スクリーンショット 2024-08-13 133449](https://github.com/user-attachments/assets/27291fef-0f9e-47aa-b332-56196a66855e)


### ○MethodArgumentTypeMismatchExceptionのレスポンスのメッセージの修正
34d9177ffe4184014e88165142f2bcab815a430d

