### PR TITLE
deleteStudentにてtry-catch文でMethodArgumentTypeMismatchExceptionを投げるように修正

### DIFF
--- a/src/main/java/com/koichi/assignment8/controller/StudentController.java
+++ b/src/main/java/com/koichi/assignment8/controller/StudentController.java
@@ -106,8 +106,14 @@ public class StudentController {
      * 指定したidのstudentのデータを削除します。
      */
     @DeleteMapping("/students/{id}")
-    public ResponseEntity<StudentResponse> deleteStudent(@PathVariable("id") Integer id) {
-        studentService.deleteStudent(id);
+    public ResponseEntity<StudentResponse> deleteStudent(@PathVariable("id") String id) {
+        int intTypeConvertedId;
+        try {
+            intTypeConvertedId = Integer.parseInt(id);
+            studentService.deleteStudent(intTypeConvertedId);
+        } catch (NumberFormatException e) {
+            throw new MethodArgumentTypeMismatchException("IDは数字で入力してください");
+        }
         StudentResponse body = new StudentResponse("Student deleted");
         return ResponseEntity.ok(body);
     }


### PR DESCRIPTION
### ◎deleteStudentにてtry-catch文でMethodArgumentTypeMismatchExceptionを投げるように修正

今回は、deleteStudentにてtry-catch文でMethodArgumentTypeMismatchExceptionを投げるように修正
いたしましたので、ご確認よろしくお願いいたします。


### ○deleteStudentにてtry-catch文でMethodArgumentTypeMismatchExceptionを投げるように修正
66106c74fb977e7bdd3db4e94150b44801521880

#### 実行結果
 - 文字列の場合

![スクリーンショット 2024-08-28 100310](https://github.com/user-attachments/assets/ba828fcc-b89c-4751-a7d8-4402fdce0d60)


 - 空白だった場合
![スクリーンショット 2024-08-28 100412](https://github.com/user-attachments/assets/31e827db-fc37-4efe-9839-72fc29ffaa7f)

 